### PR TITLE
search returns scraped tweets even when requested number is not reached

### DIFF
--- a/twitter/search.py
+++ b/twitter/search.py
@@ -58,6 +58,7 @@ class Search:
             r, data, next_cursor = await self.backoff(lambda: self.get(session, config), query)
         except Exception as e:
             data = {}
+            logger.debug(f'[{RED}Failure{RESET}] no data found. Try changing the query or checking if the account is suspended (in this case try again in 15 minutes).')
         if data:
             all_data = [data]
             c = colors.pop() if colors else ''
@@ -83,7 +84,7 @@ class Search:
                         encoding='utf-8'
                     )
                     all_data.append(data)
-        logger.debug(f'[{RED}Failure{RESET}] no data found. Try changing the query or checking if the account is suspended (in this case try again in 15 minutes).')
+        
         return all_data
 
     async def backoff(self, fn, info, retries=3):


### PR DESCRIPTION
Now the max retry number is 3 (I never found a case where waiting would give me more results, but we retry a few times just in case)

Red alert and a friendly message if no data is found:

![image](https://github.com/trevorhobenshield/twitter-api-client/assets/18517054/349a60a3-751a-44e9-8ca3-e0ed3653b138)

Yellow alert if we are able to scrape a few tweets but not the requested number:

![image](https://github.com/trevorhobenshield/twitter-api-client/assets/18517054/0612036a-3c2e-4625-9137-67a2bd35e227)

I didn't find a way to see if the account is temporarily suspend of searching, but maybe I'm not looking in the right direction. If you could point me on how to solve that, I could try in the next few days...