### PR TITLE
Raise an exception for an erroring status code

### DIFF
--- a/twitter/search.py
+++ b/twitter/search.py
@@ -82,6 +82,7 @@ class Search:
     async def get(self, client: AsyncClient, params: dict) -> tuple:
         _, qid, name = Operation.SearchTimeline
         r = await client.get(f'https://twitter.com/i/api/graphql/{qid}/{name}', params=build_params(params))
+        r.raise_for_status()
         data = r.json()
         cursor = self.get_cursor(data)
         entries = [y for x in find_key(data, 'entries') for y in x if re.search(r'^(tweet|user)-', y['entryId'])]


### PR DESCRIPTION
Fixes #112.

```python
> await search.get(client, params)

Traceback (most recent call last):
  File "/python3.10/concurrent/futures/_base.py", line 458, in result
    return self.__get_result()
  File "/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "<console>", line 1, in <module>
  File "/python3.10/site-packages/twitter/search.py", line 85, in get
    r.raise_for_status()
  File "/python3.10/site-packages/httpx/_models.py", line 749, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Client error '429 Too Many Requests' for url 'https://twitter.com/i/api/graphql/…'
For more information check: https://httpstatuses.com/429
```

^^ This hopefully makes it a bit clearer what has gone wrong, and is also a neater exception to catch and handle.