### PR TITLE
Custom httpx proxy and user_agent for Scraper

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,29 @@
 pip install twitter-api-client -U
 ```
 
+## New
+Scraper now supports httpx proxy settings 
+
+```bash
+pip install httpx[socks]
+```
+
+```python
+from twitter.scraper import Scraper
+
+#
+proxy_url="socks5://username:paswword@host:port"
+httpx_proxies={"http://": proxy_url, "https://": proxy_url}
+
+
+## resume session using cookies (JSON file) and use proxy
+scraper = Scraper(cookies='twitter.cookies', httpx_proxies=httpx_proxies)
+
+## if you want to use the scraper as regular without proxy...
+scraper = Scraper(cookies='twitter.cookies')
+```
+
+
 ### Automation
 
 ![](assets/account.gif)

--- a/twitter/scraper.py
+++ b/twitter/scraper.py
@@ -33,7 +33,6 @@ if platform.system() != 'Windows':
 
 class Scraper:
     def __init__(self, email: str = None, username: str = None, password: str = None, session: Client = None, httpx_proxies: dict = {}, **kwargs):
-        self.httpx_proxies = httpx_proxies
         self.save = kwargs.get('save', True)
         self.debug = kwargs.get('debug', 0)
         self.pbar = kwargs.get('pbar', True)

--- a/twitter/scraper.py
+++ b/twitter/scraper.py
@@ -33,6 +33,7 @@ if platform.system() != 'Windows':
 
 class Scraper:
     def __init__(self, email: str = None, username: str = None, password: str = None, session: Client = None, httpx_proxies: dict = {}, **kwargs):
+        self.httpx_proxies = httpx_proxies
         self.save = kwargs.get('save', True)
         self.debug = kwargs.get('debug', 0)
         self.pbar = kwargs.get('pbar', True)

--- a/twitter/scraper.py
+++ b/twitter/scraper.py
@@ -32,8 +32,10 @@ if platform.system() != 'Windows':
 
 
 class Scraper:
-    def __init__(self, email: str = None, username: str = None, password: str = None, session: Client = None, httpx_proxies: dict = {}, **kwargs):
+    def __init__(self, email: str = None, username: str = None, password: str = None, session: Client = None, httpx_proxies: dict = {}, user_agent: str = None, **kwargs):
         self.httpx_proxies = httpx_proxies
+        self.user_agent = user_agent
+
         self.save = kwargs.get('save', True)
         self.debug = kwargs.get('debug', 0)
         self.pbar = kwargs.get('pbar', True)
@@ -268,7 +270,11 @@ class Scraper:
                 'max_keepalive_connections': kwargs.pop('max_keepalive_connections', None),
                 'keepalive_expiry': kwargs.pop('keepalive_expiry', 5.0),
             }
-            headers = {'user-agent': random.choice(USER_AGENTS)}
+            if(self.user_agent != None):
+                headers = {'user-agent': self.user_agent}
+            else: 
+                headers = {'user-agent': random.choice(USER_AGENTS)}
+
             async with AsyncClient(proxies=self.httpx_proxies, limits=Limits(**limits), headers=headers, http2=True, verify=False, timeout=60, follow_redirects=True) as client:
                 return await tqdm_asyncio.gather(*(fn(client=client) for fn in fns), desc='Downloading Media')
 


### PR DESCRIPTION
Added support for optional usage of proxies and custom user-agents that can be passed in the construction of the Scraper Class. If the options are not provided, the Scraper class will use the random user agent and no proxy. 

