### PR TITLE
Fixes SyntaxWarning errors in regex

### DIFF
--- a/twitter/account.py
+++ b/twitter/account.py
@@ -775,7 +775,7 @@ class Account:
         return self.gql('POST', Operation.DeleteScheduledTweet, variables)
 
     def clear_scheduled_tweets(self) -> None:
-        user_id = int(re.findall('"u=(\d+)"', self.session.cookies.get('twid'))[0])
+        user_id = int(re.findall(r'"u=(\d+)"', self.session.cookies.get('twid'))[0])
         drafts = self.gql('GET', Operation.FetchScheduledTweets, {"ascending": True})
         for _id in set(find_key(drafts, 'rest_id')):
             if _id != user_id:
@@ -790,7 +790,7 @@ class Account:
         return self.gql('POST', Operation.DeleteDraftTweet, variables)
 
     def clear_draft_tweets(self) -> None:
-        user_id = int(re.findall('"u=(\d+)"', self.session.cookies.get('twid'))[0])
+        user_id = int(re.findall(r'"u=(\d+)"', self.session.cookies.get('twid'))[0])
         drafts = self.gql('GET', Operation.FetchDraftTweets, {"ascending": True})
         for _id in set(find_key(drafts, 'rest_id')):
             if _id != user_id:
@@ -829,7 +829,7 @@ class Account:
     @property
     def id(self) -> int:
         """ Get User ID """
-        return int(re.findall('"u=(\d+)"', self.session.cookies.get('twid'))[0])
+        return int(re.findall(r'"u=(\d+)"', self.session.cookies.get('twid'))[0])
 
     def save_cookies(self, fname: str = None):
         """ Save cookies to file """

--- a/twitter/scraper.py
+++ b/twitter/scraper.py
@@ -492,7 +492,7 @@ class Scraper:
                 headers={'authority': url.host}
             )
             # don't need an m3u8 parser
-            chunks = re.findall('\n(chunk_.*)\n', r.text, flags=re.I)
+            chunks = re.findall(r'\n(chunk_.*)\n', r.text, flags=re.I)
             url = '/'.join(location.split('/')[:-1])
             return [f'{url}/{chunk}' for chunk in chunks]
         except Exception as e:
@@ -546,7 +546,7 @@ class Scraper:
         [streams.setdefault(_id, []).append(chunk) for _id, chunk in chunks]
         # ensure chunks are in correct order
         for k, v in streams.items():
-            streams[k] = sorted(v, key=lambda x: int(re.findall('_(\d+)_\w\.aac$', x.url.path)[0]))
+            streams[k] = sorted(v, key=lambda x: int(re.findall(r'_(\d+)_\w\.aac$', x.url.path)[0]))
         out = self.out / 'audio'
         out.mkdir(parents=True, exist_ok=True)
         for space_id, chunks in streams.items():
@@ -717,7 +717,7 @@ class Scraper:
                                     print()
                                     print(f"({rand_color()}{user}{RESET})")
                                     prev_user = user
-                                new_message = re.sub(f'^({prev_message})', '', message, flags=re.I).strip()
+                                new_message = re.sub(fr'^({prev_message})', '', message, flags=re.I).strip()
                                 if len(new_message) < 100:
                                     print(new_message, end=' ')
                                     prev_message = message
@@ -771,9 +771,9 @@ class Scraper:
         @param rooms: list of room ids
         @return: None
         """
-        chunk_idx = lambda chunk: re.findall('_(\d+)_\w\.aac', chunk)[0]
+        chunk_idx = lambda chunk: re.findall(r'_(\d+)_\w\.aac', chunk)[0]
         sort_chunks = lambda chunks: sorted(chunks, key=lambda x: int(chunk_idx(x)))
-        parse_chunks = lambda txt: re.findall('\n(chunk_.*)\n', txt, flags=re.I)
+        parse_chunks = lambda txt: re.findall(r'\n(chunk_.*)\n', txt, flags=re.I)
 
         async def get_m3u8(client: AsyncClient, space: dict) -> dict:
             try:
@@ -894,7 +894,7 @@ class Scraper:
     @property
     def id(self) -> int:
         """ Get User ID """
-        return int(re.findall('"u=(\d+)"', self.session.cookies.get('twid'))[0])
+        return int(re.findall(r'"u=(\d+)"', self.session.cookies.get('twid'))[0])
 
     def save_cookies(self, fname: str = None):
         """ Save cookies to file """


### PR DESCRIPTION
This PR fixes `SyntaxWarning: invalid escape sequence` errors on regex when using Python 3.12+ by converting the _pattern_ to raw strings (`r’’`)