### PR TITLE
Fixes error getting user ID when using cookies identification

### DIFF
--- a/twitter/account.py
+++ b/twitter/account.py
@@ -829,7 +829,10 @@ class Account:
     @property
     def id(self) -> int:
         """ Get User ID """
-        return int(re.findall('"u=(\d+)"', self.session.cookies.get('twid'))[0])
+        twid = self.session.cookies.get('twid')
+        if not twid:
+            raise Exception(f'[{RED}error{RESET}] No "twid" cookie found')
+        return int(re.findall(r'u%3D(\d+)' if self.session._init_with_cookies else r'"u=(\d+)"', twid)[0])
 
     def save_cookies(self, fname: str = None):
         """ Save cookies to file """


### PR DESCRIPTION
Currently, `Account.id` returns an error if we’re using cookies identification method:

```
account = Account(cookies={
    'ct0': '…’,
    'auth_token': '…’,
    'twid': 'u%3D…’
})

print(account.id)
```

```
Traceback (most recent call last):
  File "xxxx.py", line 38, in <module>
    print(account.id())
          ^^^^^^^^^^
  File "XXXX/twitter/account.py", line 832, in id
    return int(re.findall('"u=(\d+)"', self.session.cookies.get('twid'))[0])
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

This PR fixes this issue by changing the regex pattern if `session._init_with_cookies` is set.